### PR TITLE
feat: build improvements with caching and buildx

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,14 @@ outputs:
   new_tag:
     description: "The new tag which was generated"
     value: ${{ steps.generate-and-push-tag.outputs.new_tag }}
-runs-on: ubuntu-latest
 runs:
   using: 'composite'
   steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver-opts: |
+          network=host
     - name: Build And Push Tag
       id: generate-and-push-tag
       run: |

--- a/build.sh
+++ b/build.sh
@@ -27,13 +27,30 @@ else
 fi
 echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
+# Set up Docker Buildx for optimized builds
+docker buildx create --use --driver docker-container --name multiarch --bootstrap 2>/dev/null || docker buildx use multiarch
+
 docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD
+
+echo "Building optimized Docker image with caching...";
 if [ -n "$SENTRY_AUTH_TOKEN" ]; then
-    docker build -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$NEW_TAG --build-arg SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" .
+    docker buildx build \
+        --platform linux/amd64 \
+        --cache-from type=gha \
+        --cache-to type=gha,mode=max \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        --build-arg SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
+        -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$NEW_TAG \
+        --push .
 else
-    docker build -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$NEW_TAG .
+    docker buildx build \
+        --platform linux/amd64 \
+        --cache-from type=gha \
+        --cache-to type=gha,mode=max \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$NEW_TAG \
+        --push .
 fi
-echo "Pushing Docker Image to Docker Hub";
-docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:$NEW_TAG
+
 echo "NEW_TAG=v$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 echo "New tag: $NEW_TAG";


### PR DESCRIPTION
This pull request introduces support for Docker Buildx to enable multi-platform builds and optimize Docker image creation with caching. The changes primarily enhance the build process in `build.sh` and update the GitHub Actions workflow in `action.yml`.

### Enhancements to Docker build process:

* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R30-R54): Integrated Docker Buildx to support multi-platform builds and caching. It includes setting up a Buildx builder, specifying the target platform (`linux/amd64`), and configuring caching with GitHub Actions cache (`--cache-from` and `--cache-to`). The `docker build` commands were replaced with `docker buildx build` for optimized builds.

### Updates to GitHub Actions workflow:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L10-R17): Added a step to set up Docker Buildx in the workflow using the `docker/setup-buildx-action@v3` action. This ensures the build environment is prepared for Buildx-based operations.